### PR TITLE
Fix Fatal B9 Part switch error if Extraplanetary launchpads isnt installed

### DIFF
--- a/VABOrganzier-patches/Extraplanetary Launchpads/EL-VABorganizer.cfg
+++ b/VABOrganzier-patches/Extraplanetary Launchpads/EL-VABorganizer.cfg
@@ -1,7 +1,9 @@
 // Support for Extraplanetary Launchpads
 // There's probably an easier way to do this, but I just wrote down each part manually
 
-@PART[ELWorkshop|ELOrbitalDock|ELLandingPad|ELLaunchpad2|ELRocketBuilder|ELConstructionDrone_v2|ELMicroPad|ELControlReference]:FOR[ExtraplanetaryLaunchpads]:NEEDS[VABOrganizer]
+//Changed ":FOR[ExtraplanetaryLaunchpads]" to ":NEEDS[ExtraplanetaryLaunchpads]" to prevent fatal B9 part switch errors if Extraplanetary launchers isn't installed -LightningRadiant
+
+@PART[ELWorkshop|ELOrbitalDock|ELLandingPad|ELLaunchpad2|ELRocketBuilder|ELConstructionDrone_v2|ELMicroPad|ELControlReference]:NEEDS[ExtraplanetaryLaunchpads]:NEEDS[VABOrganizer]
 {
   %VABORGANIZER
   {
@@ -9,7 +11,7 @@
   }
 }
 
-@PART[ELTinySmelter|ELSmallSmelter|ELSmelter|ELRecycleBin|ELRecycleBin_Large|ELLathe]:FOR[ExtraplanetaryLaunchpads]:NEEDS[VABOrganizer]
+@PART[ELTinySmelter|ELSmallSmelter|ELSmelter|ELRecycleBin|ELRecycleBin_Large|ELLathe]:NEEDS[ExtraplanetaryLaunchpads]:NEEDS[VABOrganizer]
 {
   %VABORGANIZER
   {
@@ -17,7 +19,7 @@
   }
 }
 
-@PART[ELTinyAuger|ELSmallAuger|ELAuger|ELMallet|ELSurveyStake|ELMagnetometer|ELOMD]:FOR[ExtraplanetaryLaunchpads]:NEEDS[VABOrganizer]
+@PART[ELTinyAuger|ELSmallAuger|ELAuger|ELMallet|ELSurveyStake|ELMagnetometer|ELOMD]:NEEDS[ExtraplanetaryLaunchpads]:NEEDS[VABOrganizer]
 {
   %VABORGANIZER
   {
@@ -25,7 +27,7 @@
   }
 }
 
-@PART[ELTankSmlMTL|ELTankMedMTL|ELTankLargeMTL|ELTankXLargeMTL|HexCanMetalSmall|HexCanMetal|HexCanMetalLarge|HexCanMetalHuge]:FOR[ExtraplanetaryLaunchpads]:NEEDS[VABOrganizer]
+@PART[ELTankSmlMTL|ELTankMedMTL|ELTankLargeMTL|ELTankXLargeMTL|HexCanMetalSmall|HexCanMetal|HexCanMetalLarge|HexCanMetalHuge]:NEEDS[ExtraplanetaryLaunchpads]:NEEDS[VABOrganizer]
 {
   %VABORGANIZER
   {
@@ -33,7 +35,7 @@
   }
 }
 
-@PART[ELTankSmlORE|ELTankMedORE|ELTankLargeORE|ELTankXLargeORE|HexCanOreSmall|HexCanOre|HexCanOreLarge|HexCanOreHuge]:FOR[ExtraplanetaryLaunchpads]:NEEDS[VABOrganizer]
+@PART[ELTankSmlORE|ELTankMedORE|ELTankLargeORE|ELTankXLargeORE|HexCanOreSmall|HexCanOre|HexCanOreLarge|HexCanOreHuge]:NEEDS[ExtraplanetaryLaunchpads]:NEEDS[VABOrganizer]
 {
   %VABORGANIZER
   {
@@ -41,7 +43,7 @@
   }
 }
 
-@PART[ELTankSmlRP|ELTankMedRP|ELTankLargeRP|ELTankXLargeRP|HexCanRocketPartsSmall|HexCanRocketParts|HexCanRocketPartsLarge|HexCanRocketPartsHuge]:FOR[ExtraplanetaryLaunchpads]:NEEDS[VABOrganizer]
+@PART[ELTankSmlRP|ELTankMedRP|ELTankLargeRP|ELTankXLargeRP|HexCanRocketPartsSmall|HexCanRocketParts|HexCanRocketPartsLarge|HexCanRocketPartsHuge]:NEEDS[ExtraplanetaryLaunchpads]:NEEDS[VABOrganizer]
 {
   %VABORGANIZER
   {
@@ -49,7 +51,7 @@
   }
 }
 
-@PART[RocketpartsSmall7x|Rocketparts7x|RocketpartsLarge7x|RocketpartsHuge7x]:FOR[ExtraplanetaryLaunchpads]:NEEDS[VABOrganizer]
+@PART[RocketpartsSmall7x|Rocketparts7x|RocketpartsLarge7x|RocketpartsHuge7x]:NEEDS[ExtraplanetaryLaunchpads]:NEEDS[VABOrganizer]
 {
   %VABORGANIZER
   {
@@ -57,7 +59,7 @@
   }
 }
 
-@PART[ELTankSmlSCRAP|ELTankMedSCRAP|ELTankLargeSCRAP|ELTankXLargeSCRAP]:FOR[ExtraplanetaryLaunchpads]:NEEDS[VABOrganizer]
+@PART[ELTankSmlSCRAP|ELTankMedSCRAP|ELTankLargeSCRAP|ELTankXLargeSCRAP]:NEEDS[ExtraplanetaryLaunchpads]:NEEDS[VABOrganizer]
 {
   %VABORGANIZER
   {


### PR DESCRIPTION
Due to some error B9 part switch gives a fatal error when launching if this is installed but not Extraplanetary Launchpads (its possible this also happens for some other mods but i have them installed, I haven't done any testing other than seeing that this fixed my problem.)

Top comment on [this](https://www.reddit.com/r/KerbalSpaceProgram/comments/1h5gpbq/b9partswitchfatal_error_while_loading/) is where i got what i needed to fix it, I dont write module manager stuff :